### PR TITLE
Add RELEASE.md and fix mix.exs.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+# Release process
+
+## Shipping a new version
+
+1. Update version in mix.exs
+
+2. Commit changes above with title "Release vVERSION"
+
+3. Open a pull request for release commit.
+
+4. Once merged and CI passes for master,
+
+5. Checkout latest master locally.
+
+6. Create and push a git tag for release.
+
+7. `mix hex.publish`

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Harald.MixProject do
       dialyzer: [
         flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs, :overspecs]
       ],
+      docs: docs(),
       elixir: "~> 1.7",
       package: package(),
       source_url: "https://github.com/verypossible/harald",
@@ -40,9 +41,17 @@ defmodule Harald.MixProject do
     """
   end
 
+  defp docs do
+    [
+      main: "README",
+      extras: [
+        "README.md"
+      ]
+    ]
+  end
+
   defp package do
     [
-      organization: :very,
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/verypossible/harald"}
     ]


### PR DESCRIPTION
Why:

* We want to release v0.1.0 of Harald!!!

This change addresses the need by:

* Add a release checklist for future publishers of this package.
* Remove organization from mix.exs package config as we want this to be
  global.
* Configure docs to use README.md as the home page.