### PR TITLE
Fix docs.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Harald.MixProject do
 
   defp docs do
     [
-      main: "README",
+      main: "readme",
       extras: [
         "README.md"
       ]


### PR DESCRIPTION
Why:

* Docs generation lowercases all filenames.

This change addresses the need by:

* Lowercase the main doc.