### PR TITLE
Sweeping refactor

### DIFF
--- a/dialyzer_ignore.exs
+++ b/dialyzer_ignore.exs
@@ -1,0 +1,3 @@
+[
+  ~r/test\/support\/generators.*return/
+]

--- a/lib/harald/assigned_numbers/company_identifiers.ex
+++ b/lib/harald/assigned_numbers/company_identifiers.ex
@@ -1,0 +1,24 @@
+defmodule Harald.AssignedNumbers.CompanyIdentifiers do
+  @moduledoc """
+  > Company identifiers are unique numbers assigned by the Bluetooth SIG to member companies
+  > requesting one.
+
+  Reference: https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
+  """
+
+  @definitions %{
+    0x004C => "Apple, Inc."
+  }
+
+  Enum.each(@definitions, fn
+    {id, description} ->
+      def description(unquote(id)), do: unquote(description)
+
+      def id(unquote(description)), do: unquote(id)
+  end)
+
+  @doc """
+  Returns a list of all Company Identifier ids.
+  """
+  defmacro ids, do: unquote(for {id, _} <- @definitions, do: id)
+end

--- a/lib/harald/assigned_numbers/generic_access_profile.ex
+++ b/lib/harald/assigned_numbers/generic_access_profile.ex
@@ -1,0 +1,69 @@
+defmodule Harald.AssignedNumbers.GenericAccessProfile do
+  @moduledoc """
+  > Assigned numbers are used in GAP for inquiry response, EIR data type values,
+  > manufacturer-specific data, advertising data, low energy UUIDs and appearance characteristics,
+  > and class of device.
+
+  Reference: https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile
+  """
+
+  @definitions %{
+    0x01 => "Flags",
+    0x02 => "Incomplete List of 16-bit Service Class UUIDs",
+    0x03 => "Complete List of 16-bit Service Class UUIDs",
+    0x04 => "Incomplete List of 32-bit Service Class UUIDs",
+    0x05 => "Complete List of 32-bit Service Class UUIDs",
+    0x06 => "Incomplete List of 128-bit Service Class UUIDs",
+    0x07 => "Complete List of 128-bit Service Class UUIDs",
+    0x08 => "Shortened Local Name",
+    0x09 => "Complete Local Name",
+    0x0A => "Tx Power Level",
+    0x0D => "Class of Device",
+    0x0E => "Simple Pairing Hash C-192",
+    0x0F => "Simple Pairing Randomizer R-192",
+    0x10 => "Device ID",
+    0x11 => "Security Manager Out of Band Flags",
+    0x12 => "Slave Connection Interval Range",
+    0x14 => "List of 16-bit Service Solicitation UUIDs",
+    0x15 => "List of 128-bit Service Solicitation UUIDs",
+    0x16 => "Service Data - 16-bit UUID",
+    0x17 => "Public Target Address",
+    0x18 => "Random Target Address",
+    0x19 => "Appearance",
+    0x1A => "Advertising Interval",
+    0x1B => "LE Bluetooth Device Address",
+    0x1C => "LE Role",
+    0x1D => "Simple Pairing Hash C-256",
+    0x1E => "Simple Pairing Randomizer R-256",
+    0x1F => "List of 32-bit Service Solicitation UUIDs",
+    0x20 => "Service Data - 32-bit UUID",
+    0x21 => "Service Data - 128-bit UUID",
+    0x22 => "LE Secure Connections Confirmation Value",
+    0x23 => "LE Secure Connections Random Value",
+    0x24 => "URI",
+    0x25 => "Indoor Positioning",
+    0x26 => "Transport Discovery Data",
+    0x27 => "LE Supported Features",
+    0x28 => "Channel Map Update Indication",
+    0x29 => "PB-ADV",
+    0x2A => "Mesh Message",
+    0x2B => "Mesh Beacon",
+    0x3D => "3D Information Data",
+    0xFF => "Manufacturer Specific Data"
+  }
+
+  # handle a redundent GAP definition
+  defmacro id("Simple Pairing Hash C"), do: 0x0E
+
+  Enum.each(@definitions, fn
+    {id, description} ->
+      defmacro description(unquote(id)), do: unquote(description)
+
+      defmacro id(unquote(description)), do: unquote(id)
+  end)
+
+  @doc """
+  Returns a list of all Generic Access Profile Data Type Values.
+  """
+  defmacro ids, do: unquote(for {id, _} <- @definitions, do: id)
+end

--- a/lib/harald/data_type/manufacturer_behaviour.ex
+++ b/lib/harald/data_type/manufacturer_behaviour.ex
@@ -1,0 +1,12 @@
+defmodule Harald.ManufacturerDataBehaviour do
+  @moduledoc """
+  Defines a behaviour that manufacturer data modules should implement.
+  """
+
+  @doc """
+  Returns the company associated with some manufacturer data.
+
+  See: `Harald.CompanyIdentifiers`
+  """
+  @callback company :: String.t()
+end

--- a/lib/harald/data_type/manufacturer_data.ex
+++ b/lib/harald/data_type/manufacturer_data.ex
@@ -1,0 +1,67 @@
+defmodule Harald.ManufacturerData do
+  @moduledoc """
+  > The Manufacturer Specific data type is used for manufacturer specific data.
+
+  Reference: Core Specification Supplement, Part A, section 1.4.1
+
+  Modules under the `Harald.ManufacturerData` scope should implement the
+  `Harald.ManufacturerDataBehaviour` and `Harald.Serializable` behaviours.
+  """
+
+  alias Harald.ManufacturerData.Apple
+  require Harald.AssignedNumbers.CompanyIdentifiers, as: CompanyIdentifiers
+
+  @modules [Apple]
+
+  def modules, do: @modules
+
+  @doc """
+  Serializes manufacturer data.
+  """
+  def serialize(data)
+
+  Enum.each(@modules, fn
+    module ->
+      def serialize({unquote(module.company()), data}) do
+        data
+        |> unquote(module).serialize()
+        |> case do
+          {:ok, bin} ->
+            {:ok, <<unquote(CompanyIdentifiers.id(module.company())), bin::binary>>}
+
+          :error ->
+            error = %{
+              remaining: data,
+              serialized: <<unquote(CompanyIdentifiers.id(module.company()))>>
+            }
+
+            {:error, error}
+        end
+      end
+  end)
+
+  def serialize({:error, _} = ret), do: ret
+
+  def serialize(ret), do: {:error, ret}
+
+  @doc """
+  Deserializes a manufacturer data binary.
+  """
+  def deserialize(binary)
+
+  Enum.each(@modules, fn
+    module ->
+      def deserialize(
+            <<unquote(CompanyIdentifiers.id(module.company()))::little, sub_bin::binary>> = bin
+          ) do
+        case unquote(module).deserialize(sub_bin) do
+          {:ok, data} -> {:ok, {unquote(module).company, data}}
+          {:error, _} -> {:error, bin}
+        end
+      end
+  end)
+
+  def deserialize(bin) do
+    {:error, {:unhandled_company_id, bin}}
+  end
+end

--- a/lib/harald/data_type/manufacturer_data/apple.ex
+++ b/lib/harald/data_type/manufacturer_data/apple.ex
@@ -1,0 +1,93 @@
+defmodule Harald.ManufacturerData.Apple do
+  @moduledoc """
+  Serialization module for Apple.
+
+  ## iBeacon
+
+  Reference: https://en.wikipedia.org/wiki/IBeacon#Packet_Structure_Byte_Map
+  """
+
+  alias Harald.{ManufacturerDataBehaviour, Serializable}
+
+  @behaviour ManufacturerDataBehaviour
+
+  @behaviour Serializable
+
+  @ibeacon_name "iBeacon"
+
+  @ibeacon_identifier 0x02
+
+  @ibeacon_length 0x15
+
+  @impl ManufacturerDataBehaviour
+  def company, do: "Apple, Inc."
+
+  @doc """
+  Indicates iBeacon data.
+  """
+  def ibeacon_identifier, do: @ibeacon_identifier
+
+  @doc """
+  Length of the data following the length byte.
+  """
+  def ibeacon_length, do: @ibeacon_length
+
+  @doc """
+      iex> serialize({"iBeacon", %{major: 1, minor: 2, tx_power: 3, uuid: 4}})
+      {:ok, <<2, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 0, 2, 3>>}
+
+      iex> serialize({"iBeacon", %{major: 1, minor: 2, tx_power: 3}})
+      :error
+
+      iex> serialize(:orange)
+      :error
+  """
+  @impl Serializable
+  def serialize(
+        {@ibeacon_name,
+         %{
+           major: major,
+           minor: minor,
+           tx_power: tx_power,
+           uuid: uuid
+         }}
+      ) do
+    binary = <<
+      @ibeacon_identifier,
+      @ibeacon_length,
+      uuid::size(128),
+      major::size(16),
+      minor::size(16),
+      tx_power
+    >>
+
+    {:ok, binary}
+  end
+
+  def serialize(_), do: :error
+
+  @doc """
+      iex> deserialize(<<2, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 0, 2, 3>>)
+      {:ok, {"iBeacon", %{major: 1, minor: 2, tx_power: 3, uuid: 4}}}
+  """
+  @impl Serializable
+  def deserialize(<<@ibeacon_identifier, @ibeacon_length, binary::binary>>) do
+    <<
+      uuid::size(128),
+      major::size(16),
+      minor::size(16),
+      tx_power
+    >> = binary
+
+    data = %{
+      major: major,
+      minor: minor,
+      tx_power: tx_power,
+      uuid: uuid
+    }
+
+    {:ok, {"iBeacon", data}}
+  end
+
+  def deserialize(bin), do: {:error, bin}
+end

--- a/lib/harald/error_code.ex
+++ b/lib/harald/error_code.ex
@@ -1,0 +1,96 @@
+defmodule Harald.ErrorCode do
+  @moduledoc """
+  Defines all error codes and functions to map between error code and name.
+
+  > When a command fails, or an LMP, LL, or AMP message needs to indicate a failure, error codes
+  > are used to indicate the reason for the error. Error codes have a size of one octet.
+
+  Reference: Version 5.0, Vol 2, Part D, 1
+
+  ## Non-standard Names
+
+  For error codes `0x2B`, `0x31`, and `0x33`, their respective names are suffixed like ` (0x2B) as
+  to differentiate between the three when serializing.
+  """
+
+  # Reference: Version 5.0, Vol 2, Part D, 1.3
+  @error_codes %{
+    0x00 => "Success",
+    0x01 => "Unknown HCI Command",
+    0x02 => "Unknown Connection Identifier",
+    0x03 => "Hardware Failure",
+    0x04 => "Page Timeout",
+    0x05 => "Authentication Failure",
+    0x06 => "PIN or Key Missing",
+    0x07 => "Memory Capacity Exceeded",
+    0x08 => "Connection Timeout",
+    0x09 => "Connection Limit Exceeded",
+    0x0A => "Synchronous Connection Limit To A Device Exceeded",
+    0x0B => "Connection Already Exists",
+    0x0C => "Command Disallowed",
+    0x0D => "Connection Rejected due to Limited Resources",
+    0x0E => "Connection Rejected Due To Security Reasons",
+    0x0F => "Connection Rejected due to Unacceptable BD_ADDR",
+    0x10 => "Connection Accept Timeout Exceeded",
+    0x11 => "Unsupported Feature or Parameter Value",
+    0x12 => "Invalid HCI Command Parameters",
+    0x13 => "Remote User Terminated Connection",
+    0x14 => "Remote Device Terminated Connection due to Low Resources",
+    0x15 => "Remote Device Terminated Connection due to Power Off",
+    0x16 => "Connection Terminated By Local Host",
+    0x17 => "Repeated Attempts",
+    0x18 => "Pairing Not Allowed",
+    0x19 => "Unknown LMP PDU",
+    0x1A => "Unsupported Remote Feature / Unsupported LMP Feature",
+    0x1B => "SCO Offset Rejected",
+    0x1C => "SCO Interval Rejected",
+    0x1D => "SCO Air Mode Rejected",
+    0x1E => "Invalid LMP Parameters / Invalid LL Parameters",
+    0x1F => "Unspecified Error",
+    0x20 => "Unsupported LMP Parameter Value / Unsupported LL Parameter Value",
+    0x21 => "Role Change Not Allowed",
+    0x22 => "LMP Response Timeout / LL Response Timeout",
+    0x23 => "LMP Error Transaction Collision / LL Procedure Collision",
+    0x24 => "LMP PDU Not Allowed",
+    0x25 => "Encryption Mode Not Acceptable",
+    0x26 => "Link Key cannot be Changed",
+    0x27 => "Requested QoS Not Supported",
+    0x28 => "Instant Passed",
+    0x29 => "Pairing With Unit Key Not Supported",
+    0x2A => "Different Transaction Collision",
+    0x2B => "Reserved for Future Use (0x2B)",
+    0x2C => "QoS Unacceptable Parameter",
+    0x2D => "QoS Rejected",
+    0x2E => "Channel Classification Not Supported",
+    0x2F => "Insufficient Security",
+    0x30 => "Parameter Out Of Mandatory Range",
+    0x31 => "Reserved for Future Use (0x31)",
+    0x32 => "Role Switch Pending",
+    0x33 => "Reserved for Future Use (0x33)",
+    0x34 => "Reserved Slot Violation",
+    0x35 => "Role Switch Failed",
+    0x36 => "Extended Inquiry Response Too Large",
+    0x37 => "Secure Simple Pairing Not Supported By Host",
+    0x38 => "Host Busy - Pairing",
+    0x39 => "Connection Rejected due to No Suitable Channel Found",
+    0x3A => "Controller Busy",
+    0x3B => "Unacceptable Connection Parameters",
+    0x3C => "Advertising Timeout",
+    0x3D => "Connection Terminated due to MIC Failure",
+    0x3E => "Connection Failed to be Established",
+    0x3F => "MAC Connection Failed",
+    0x40 => "Coarse Clock Adjustment Rejected but Will Try to Adjust Using Clock Dragging",
+    0x41 => "Type0 Submap Not Defined",
+    0x42 => "Unknown Advertising Identifier",
+    0x43 => "Limit Reached",
+    0x44 => "Operation Cancelled by Host"
+  }
+
+  Enum.each(@error_codes, fn
+    {error_code, name} ->
+      def name(unquote(error_code)), do: unquote(name)
+      def error_code(unquote(name)), do: unquote(error_code)
+  end)
+
+  def all, do: @error_codes
+end

--- a/lib/harald/hci.ex
+++ b/lib/harald/hci.ex
@@ -1,22 +1,54 @@
 defmodule Harald.HCI do
   @moduledoc """
-  A module for working directly with the Bluetooth HCI.
+  > The HCI provides a uniform interface method of accessing a Bluetooth Controller’s
+  > capabilities.
+
+  Reference: Version 5.0, Vol. 2, Part E, 1
   """
 
+  alias Harald.{HCI.Event, Serializable}
+
+  @behaviour Serializable
+
+  @typedoc """
+  OpCode Group Field.
+
+  See `t:opcode/0`
+  """
   @type ogf :: 0..63
+
+  @typedoc """
+  OpCode Command Field.
+
+  See `t:opcode/0`
+  """
   @type ocf :: 0..1023
-  @type opcode :: binary
-  @type opt :: boolean | binary
-  @type opts :: binary | [opt]
+
+  @typedoc """
+  > Each command is assigned a 2 byte Opcode used to uniquely identify different types of
+  > commands. The Opcode parameter is divided into two fields, called the OpCode Group Field (OGF)
+  > and OpCode Command Field (OCF). The OGF occupies the upper 6 bits of the Opcode, while the OCF
+  > occupies the remaining 10 bits. The OGF of 0x3F is reserved for vendor-specific debug
+  > commands. The organization of the opcodes allows additional information to be inferred without
+  > fully decoding the entire Opcode.
+
+  Reference: Version 5.0, Vol. 2, Part E, 5.4.1
+  """
+  @type opcode :: binary()
+
+  @type opt :: boolean() | binary()
+
+  @type opts :: binary() | [opt()]
+
   @type command :: <<_::8, _::_*8>>
 
-  @spec opcode(ogf, ocf) :: opcode
+  @spec opcode(ogf(), ocf()) :: opcode()
   def opcode(ogf, ocf) when ogf < 64 and ocf < 1024 do
     <<opcode::size(16)>> = <<ogf::size(6), ocf::size(10)>>
-    <<opcode::size(16)-little>>
+    <<opcode::little-size(16)>>
   end
 
-  @spec command(opcode, opts) :: command
+  @spec command(opcode(), opts()) :: command()
   def command(opcode, opts \\ "")
 
   def command(opcode, [_ | _] = opts) do
@@ -42,8 +74,25 @@ defmodule Harald.HCI do
       iex> to_bin(<<1, 2, 3>>)
       <<1, 2, 3>>
   """
-  @spec to_bin(boolean | binary) :: binary
+  @spec to_bin(boolean() | binary()) :: binary()
   def to_bin(false), do: <<0>>
+
   def to_bin(true), do: <<1>>
+
   def to_bin(bin) when is_binary(bin), do: bin
+
+  @impl Serializable
+  for module <- Event.event_modules() do
+    def serialize(%unquote(module){} = event) do
+      {:ok, bin} = Event.serialize(event)
+      {:ok, <<Event.indicator(), bin::binary>>}
+    end
+  end
+
+  @impl Serializable
+  def deserialize(<<4, rest::binary>>) do
+    Event.deserialize(rest)
+  end
+
+  def deserialize(bin), do: {:error, bin}
 end

--- a/lib/harald/hci/arrayed_data.ex
+++ b/lib/harald/hci/arrayed_data.ex
@@ -1,0 +1,217 @@
+defmodule Harald.HCI.ArrayedData do
+  @moduledoc """
+  Serialization functions for arrayed data.
+
+  > Arrayed parameters are specified using the following notation: ParameterA[i]. If more than one
+  > set of arrayed parameters are specified (e.g. ParameterA[i], ParameterB[i]), then, unless
+  > noted otherwise, the order of the parameters are as follows: ParameterA[0], ParameterB[0],
+  > ParameterA[1], ParameterB[1], ParameterA[2], ParameterB[2], ... ParameterA[n], ParameterB[n]
+
+  Reference: Version 5.0, Vol 2, Part E, 5.2
+
+  Both `serialize/2` and `deserialize/4` rely on a schema to function. A schema is a keyword list
+  where each key is a field and each value shall be:
+
+  - a positive integer when denoting the size in bits of the field
+  - a three-tuple when the field itself represents the length of a subsequent variable length
+    field
+  - an atom when the field is variable length and a preceding field represents its length
+
+  For example if `length_data` itself was 8 bits and represented the length of `data` that would
+  be written as:
+
+  ```
+  [
+    length_data: {:variable, :data, 8},
+    data: :length_data
+  ]
+  ```
+  """
+
+  @type field :: atom()
+
+  @type field_size ::
+          pos_integer()
+          | {:variable, atom(), pos_integer()}
+          | atom()
+
+  @type schema :: [{field(), field_size()}, ...]
+
+  @doc """
+  Serializes a list of `structs` into their binary representation according to `schema`.
+  """
+  def serialize(schema, structs) do
+    data =
+      structs
+      |> Enum.with_index()
+      |> Map.new(fn {map, index} -> {index + 1, map} end)
+
+    length = length(structs)
+
+    serialize(schema, <<length>>, %{
+      data: data,
+      field: nil,
+      field_size: nil,
+      index: 1,
+      length: length
+    })
+  end
+
+  @doc """
+  Deserializes the binary representation of a list of structs according to `schema`.
+  """
+  def deserialize(schema, length, struct_module, bin) do
+    schema
+    |> deserialize(bin, %{
+      data: init_data(length, struct(struct_module)),
+      field: nil,
+      field_size: nil,
+      index: 1,
+      length: length,
+      variable: %{}
+    })
+    |> case do
+      {:ok, _} = ret -> ret
+      {:error, :incomplete} -> {:error, bin}
+    end
+  end
+
+  # pull a tuple off the schema - recursion base case
+  defp serialize([], bin, %{field: nil}), do: {:ok, bin}
+
+  # pull a tuple off the schema - defining variable lengths
+  defp serialize([{field, {:variable, _, _} = field_size} | schema], bin, %{field: nil} = state) do
+    serialize(schema, bin, %{state | field: field, field_size: field_size})
+  end
+
+  # pull a tuple off the schema
+  defp serialize([{field, field_size} | schema], bin, %{field: nil} = state) do
+    serialize(schema, bin, %{state | field: field, field_size: field_size})
+  end
+
+  # put data on the binary - writing variable lengths
+  defp serialize(
+         schema,
+         bin,
+         %{field_size: {:variable, field_target, field_size}, index: index, length: length} =
+           state
+       )
+       when index <= length do
+    target_length = byte_size(Map.fetch!(state.data[index], field_target))
+    bin = <<bin::binary, target_length::little-size(field_size)>>
+    serialize(schema, bin, %{state | index: index + 1})
+  end
+
+  # put data on the binary - writing variable length targets
+  defp serialize(schema, bin, %{field_size: variable_key, index: index, length: length} = state)
+       when index <= length and is_atom(variable_key) do
+    bin = <<bin::binary, Map.fetch!(state.data[index], state.field)::binary>>
+    serialize(schema, bin, %{state | index: index + 1})
+  end
+
+  # put data on the binary
+  defp serialize(schema, bin, %{field_size: field_size, index: index, length: length} = state)
+       when index <= length do
+    bin =
+      <<bin::binary, Map.fetch!(state.data[index], state.field)::integer-little-size(field_size)>>
+
+    serialize(schema, bin, %{state | index: index + 1})
+  end
+
+  # field completed
+  defp serialize(schema, bin, state) do
+    serialize(schema, bin, %{state | field: nil, field_size: nil, index: 1})
+  end
+
+  defp init_data(length, value) do
+    Enum.reduce(1..length, %{}, fn index, acc -> Map.put(acc, index, value) end)
+  end
+
+  # pull a tuple off the schema - recursion base case
+  defp deserialize([], _bin, %{field: nil} = state) do
+    ret = for index <- 1..state.length, do: state.data[index]
+    {:ok, ret}
+  end
+
+  # pull a tuple off the schema - defining variable lengths
+  defp deserialize([{field, {:variable, _, _} = field_size} | schema], bin, %{field: nil} = state) do
+    variable = Map.put(state.variable, field, [])
+    deserialize(schema, bin, %{state | field: field, field_size: field_size, variable: variable})
+  end
+
+  # pull a tuple off the schema
+  defp deserialize([{field, field_size} | schema], bin, %{field: nil} = state) do
+    deserialize(schema, bin, %{state | field: field, field_size: field_size})
+  end
+
+  # pull data off the binary - reading variable lengths
+  defp deserialize(
+         _schema,
+         <<>>,
+         %{field_size: {:variable, _, _field_size}, index: index, length: length}
+       )
+       when index <= length do
+    {:error, :incomplete}
+  end
+
+  # pull data off the binary - reading variable lengths
+  defp deserialize(
+         schema,
+         bin,
+         %{field_size: {:variable, _, field_size}, index: index, length: length} = state
+       )
+       when index <= length do
+    <<parameter::little-size(field_size), bin::binary>> = bin
+    variable = Map.update!(state.variable, state.field, &[parameter | &1])
+    deserialize(schema, bin, %{state | index: index + 1, variable: variable})
+  end
+
+  # pull data off the binary - reading variable lengths
+  defp deserialize(
+         schema,
+         bin,
+         %{field_size: {:variable, _, field_size}, index: index, length: length} = state
+       )
+       when index <= length do
+    <<parameter::little-size(field_size), bin::binary>> = bin
+    variable = Map.update!(state.variable, state.field, &[parameter | &1])
+    deserialize(schema, bin, %{state | index: index + 1, variable: variable})
+  end
+
+  # pull data off the binary - reading variable length targets
+  defp deserialize(schema, bin, %{field_size: variable_key, index: index, length: length} = state)
+       when index <= length and is_atom(variable_key) do
+    {field_size, variable} =
+      Map.get_and_update!(state.variable, variable_key, fn [field_size | rest] ->
+        {field_size, rest}
+      end)
+
+    <<parameter::binary-size(field_size), bin::binary>> = bin
+    data = Map.update!(state.data, index, &%{&1 | state.field => parameter})
+    deserialize(schema, bin, %{state | data: data, index: index + 1, variable: variable})
+  end
+
+  # pull data off the binary
+  defp deserialize(schema, bin, %{field_size: field_size, index: index, length: length} = state)
+       when index <= length do
+    case bin do
+      <<parameter::little-size(field_size), bin::binary>> ->
+        data = Map.update!(state.data, index, &%{&1 | state.field => parameter})
+        deserialize(schema, bin, %{state | data: data, index: index + 1})
+
+      _ ->
+        {:error, :incomplete}
+    end
+  end
+
+  # field completed - defining variable lengths
+  defp deserialize(schema, bin, %{field_size: {:variable, _, _}} = state) do
+    variable = Map.update!(state.variable, state.field, &Enum.reverse(&1))
+    deserialize(schema, bin, %{state | field: nil, field_size: nil, index: 1, variable: variable})
+  end
+
+  # field completed
+  defp deserialize(schema, bin, state) do
+    deserialize(schema, bin, %{state | field: nil, field_size: nil, index: 1})
+  end
+end

--- a/lib/harald/hci/event.ex
+++ b/lib/harald/hci/event.ex
@@ -1,35 +1,79 @@
 defmodule Harald.HCI.Event do
   @moduledoc """
-  Parent module for HCI events.
+  Serialization module for HCI Events.
+
+  > The HCI Event Packet is used by the Controller to notify the Host when events occur.
+
+  Reference: Version 5.0, Vol 2, Part E, 5.4.4
   """
 
-  alias __MODULE__
+  alias Harald.HCI.Event.{InquiryComplete, LEMeta}
+  alias Harald.Serializable
 
-  defmodule Unparsed do
-    @moduledoc """
-    Represents an event that does not have a parser.
-    """
+  @behaviour Serializable
 
-    @enforce_keys [:event_code, :event]
-    defstruct @enforce_keys
+  @event_modules [InquiryComplete, LEMeta]
+
+  @typedoc """
+  > Each event is assigned a 1-Octet event code used to uniquely identify different types of
+  > events.
+
+  Reference: Version 5.0, Vol 2, Part E, 5.4.4
+  """
+  @type event_code :: pos_integer()
+
+  @type t :: struct()
+
+  @type serialize_ret :: {:ok, binary()} | LEMeta.serialize_ret()
+
+  @type deserialize_ret ::
+          {:ok, t() | [t()]}
+          | {:error,
+             {:bad_event_code
+              | :unhandled_event_code, event_code()}}
+
+  @doc """
+  A list of modules representing implemented events.
+  """
+  def event_modules, do: @event_modules
+
+  @doc """
+  HCI packet indicator for HCI Event Packet.
+
+  Reference: Version 5.0, Vol 5, Part A, 2
+  """
+  def indicator, do: 4
+
+  @impl Serializable
+  @spec serialize(term()) :: serialize_ret()
+  def serialize(event)
+
+  Enum.each(@event_modules, fn module ->
+    def serialize(%unquote(module){} = event) do
+      {:ok, bin} = unquote(module).serialize(event)
+      {:ok, <<unquote(module).event_code(), byte_size(bin), bin::binary>>}
+    end
+  end)
+
+  def serialize(event), do: {:error, {:bad_event, event}}
+
+  @impl Serializable
+  @spec deserialize(binary()) :: deserialize_ret()
+  def deserialize(binary)
+
+  Enum.each(@event_modules, fn module ->
+    def deserialize(<<unquote(module.event_code()), length, event_parameters::binary>> = bin) do
+      if length == byte_size(event_parameters) do
+        unquote(module).deserialize(event_parameters)
+      else
+        {:error, bin}
+      end
+    end
+  end)
+
+  def deserialize(<<code, _::binary>> = binary) when code in 0x00..0xFF do
+    {:error, {:unhandled_event_code, binary}}
   end
 
-  @type unparsed_event :: binary
-  @type event_code :: integer
-  @type event :: %Unparsed{} | Event.LEMeta.parsed()
-
-  @le_meta_event 0x3E
-
-  for {function, value} <- [
-        le_meta_event: @le_meta_event
-      ] do
-    def unquote(function)(), do: unquote(value)
-  end
-
-  @spec parse({event_code, unparsed_event}) :: event
-  def parse({@le_meta_event, event}), do: Event.LEMeta.parse(event)
-
-  def parse({event_code, event}) when is_integer(event_code) and is_binary(event) do
-    %Unparsed{event_code: event_code, event: event}
-  end
+  def deserialize(binary), do: {:error, {:bad_event_code, binary}}
 end

--- a/lib/harald/hci/event/inquiry_complete.ex
+++ b/lib/harald/hci/event/inquiry_complete.ex
@@ -1,0 +1,28 @@
+defmodule Harald.HCI.Event.InquiryComplete do
+  @moduledoc """
+  > The Inquiry Complete event indicates that the Inquiry is finished. This event contains a
+  > Status parameter, which is used to indicate if the Inquiry completed successfully or if the
+  > Inquiry was not completed.
+  Reference: Version 5.0, Vol 2, Part E, 7.7.1
+  """
+
+  alias Harald.{ErrorCode, Serializable}
+
+  @behaviour Serializable
+
+  @type t :: %__MODULE__{}
+
+  defstruct [:status]
+
+  @event_code 0x01
+
+  def event_code, do: @event_code
+
+  @impl Serializable
+  def serialize(%__MODULE__{status: status}), do: {:ok, <<ErrorCode.error_code(status)>>}
+
+  @impl Serializable
+  def deserialize(<<status>>), do: {:ok, %__MODULE__{status: ErrorCode.name(status)}}
+
+  def deserialize(bin), do: {:error, bin}
+end

--- a/lib/harald/hci/event/le_meta.ex
+++ b/lib/harald/hci/event/le_meta.ex
@@ -1,27 +1,72 @@
 defmodule Harald.HCI.Event.LEMeta do
   @moduledoc """
-  > The LE Meta Event is used to encapsulate all LE Controller specific events. The Event Code of
-  > all LE Meta Events shall be 0x3E. The Subevent_Code is the first octet of the event
-  > parameters.  The Subevent_Code shall be set to one of the valid Subevent_Codes from an LE
-  > specific event. All other Subevent_Parameters are defined in the LE Controller specific
-  > events.
-  Bluetooth Spec v5
+  > The LE Meta Event is used to encapsulate all LE Controller specific events.
+
+  Reference: Version 5.0, Vol 2, Part E, 7.7.65
   """
 
-  @type t :: __MODULE__.AdvertisingReport.t()
-  @type parsed :: [t]
+  alias Harald.{HCI.Event.LEMeta.AdvertisingReport, Serializable}
 
-  defmodule Unparsed do
-    @moduledoc """
-    Represents an unparsed LEMeta event.
-    """
+  @behaviour Serializable
 
-    defstruct [:subevent_code, :subevent_parameters]
+  @type t :: %__MODULE__{}
+
+  @typedoc """
+  > An LE Controller uses subevent codes to transmit LE specific events from the Controller to the
+  > Host. Note: The subevent code will always be the first Event Parameter (See Section 7.7.65).
+
+  Reference: Version 5.0, Vol 2, Part E, 5.4.4
+  """
+  @type subevent_code :: pos_integer()
+
+  @type serialize_ret :: {:ok, binary()} | {:error, term()}
+
+  defstruct [:subevent]
+
+  @event_code 0x3E
+
+  @subevent_modules [
+    AdvertisingReport
+  ]
+
+  @doc """
+  See: `t:Harald.HCI.Event.event_code/0`.
+  """
+  def event_code, do: @event_code
+
+  @doc """
+  A list of modules representing implemented LEMeta subevents.
+  """
+  def subevent_modules, do: @subevent_modules
+
+  @impl Serializable
+  def serialize(event)
+
+  Enum.each(@subevent_modules, fn subevent_module ->
+    def serialize(%__MODULE__{subevent: %unquote(subevent_module){} = subevent}) do
+      unquote(subevent_module).serialize(subevent)
+    end
+  end)
+
+  def serialize(%__MODULE__{} = ret), do: {:error, ret}
+
+  @impl Serializable
+  def deserialize(binary)
+
+  for module <- @subevent_modules do
+    {module, subevent_code} =
+      case module do
+        {module, _} -> {module, module.subevent_code()}
+        module -> {module, module.subevent_code()}
+      end
+
+    # def deserialize(<<unquote(subevent_code), subevent_packet::binary>>) do
+    # Add test that executes this code and fails with above head
+    def deserialize(<<unquote(subevent_code), _::binary>> = subevent_packet) do
+      {ok_or_error, subevent} = unquote(module).deserialize(subevent_packet)
+      {ok_or_error, %__MODULE__{subevent: subevent}}
+    end
   end
 
-  def parse(<<0x02>> <> params), do: __MODULE__.AdvertisingReport.parse(params)
-
-  def parse(<<subevent_code>> <> params) do
-    %Unparsed{subevent_code: subevent_code, subevent_parameters: params}
-  end
+  def deserialize(bin), do: {:error, bin}
 end

--- a/lib/harald/hci/event/le_meta/advertising_report.ex
+++ b/lib/harald/hci/event/le_meta/advertising_report.ex
@@ -1,107 +1,104 @@
 defmodule Harald.HCI.Event.LEMeta.AdvertisingReport do
   @moduledoc """
+  A struct representing a LE Advertising Report.
+
   > The LE Advertising Report event indicates that one or more Bluetooth devices have responded to
   > an active scan or have broadcast advertisements that were received during a passive scan. The
-  > Controller may queue these advertising reports and send information from multiple devices in one
-  > LE Advertising Report event.
+  > Controller may queue these advertising reports and send information from multiple devices in
+  > one LE Advertising Report event.
   >
   > This event shall only be generated if scanning was enabled using the LE Set Scan Enable
   > command. It only reports advertising events that used legacy advertising PDUs.
-  Bluetooth Spec v5
+
+  Reference: Version 5.0, Vol 2, Part E, 7.7.65.2
   """
 
-  alias __MODULE__
+  alias Harald.HCI.{Event.LEMeta.AdvertisingReport.Device}
+  alias Harald.Serializable
 
-  @enforce_keys [:event_type, :address_type, :address, :data, :rss]
+  @enforce_keys [:devices]
+
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{}
 
-  @gap_manufacturer_data 0xFF
-  @gap_service_data_32 0x20
+  @behaviour Serializable
 
-  def merge(%AdvertisingReport{data: d1} = ar1, %AdvertisingReport{data: d2} = ar2) do
-    ar1
-    |> Map.merge(ar2)
-    |> Map.put(:data, Map.merge(d1, d2))
-  end
-
-  def parse(<<1>> <> params) do
-    <<event_type, address_type, address::size(48)-little, length_data>> <> remaining_params =
-      params
-
-    data = binary_part(remaining_params, 0, length_data)
-
-    <<rss>> = binary_part(remaining_params, length_data, 1)
-
-    [
-      %__MODULE__{
-        event_type: event_type,
-        address_type: address_type,
-        address: Integer.to_string(address, 16),
-        data: data |> parse_advertising_data() |> Map.new(),
-        rss: rss
-      }
-    ]
-  end
-
-  def parse_advertising_data(""), do: []
-
-  def parse_advertising_data(<<length_data, ad_type>> <> data) do
-    adjusted_length = length_data - 1
-    ad_datum = binary_part(data, 0, adjusted_length)
-    remainder_datum = binary_part(data, adjusted_length, byte_size(data) - adjusted_length)
-
-    [
-      parse_ad_datum(ad_type, ad_datum)
-      | parse_advertising_data(remainder_datum)
-    ]
-  end
-
-  def parse_ad_datum(@gap_manufacturer_data, <<0x4C, 0x00, 0x02, 0x15>> <> datum) do
-    <<
-      uuid::size(128),
-      major::size(16),
-      minor::size(16),
-      tx_power
-    >> = datum
-
-    ibeacon = %{
-      uuid: int_to_uuid(uuid),
-      major: major,
-      minor: minor,
-      tx_power: tx_power
-    }
-
-    {:ibeacon, ibeacon}
-  end
-
-  def parse_ad_datum(@gap_service_data_32, datum) do
-    <<
-      uuid::little-size(32),
-      rest::binary
-    >> = datum
-
-    service_data_32 = %{
-      uuid: uuid,
-      data: rest
-    }
-
-    {:service_data_32, service_data_32}
-  end
-
-  def parse_ad_datum(type, datum), do: {type, datum}
+  @subevent_code 0x02
 
   @doc """
-      iex> int_to_uuid(0x58c8d08376684590801f063c9346538e)
-      "58C8D083-7668-4590-801F-063C9346538E"
+  See: `t:Harald.HCI.Event.LEMeta.subevent_code/0`.
   """
-  def int_to_uuid(n) do
-    uuid =
-      n
-      |> Integer.to_string(16)
-      |> String.pad_leading(32, "0")
+  def subevent_code, do: @subevent_code
 
-    Regex.replace(~r/^(\w{8})(\w{4})(\w{4})(\w{4})(\w{12})$/, uuid, ~S(\1-\2-\3-\4-\5))
+  @doc """
+  Serializes a `Harald.HCI.Event.LEMeta.AdvertisingReport` struct into a LE Advertising Report
+  Event.
+
+      iex> AdvertisingReport.serialize(
+      ...>   %AdvertisingReport{
+      ...>     devices: [
+      ...>       %AdvertisingReport.Device{
+      ...>         event_type: 0,
+      ...>         address_type: 1,
+      ...>         address: 2,
+      ...>         data: [],
+      ...>         rss: 4
+      ...>       },
+      ...>       %AdvertisingReport.Device{
+      ...>         event_type: 1,
+      ...>         address_type: 2,
+      ...>         address: 5,
+      ...>         data: [{"Service Data - 32-bit UUID", %{uuid: 1, data: <<2>>}}],
+      ...>         rss: 7
+      ...>       }
+      ...>     ]
+      ...>   }
+      ...> )
+      {:ok,
+       <<2, 2, 0, 1, 1, 2, 2, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 7, 6, 32, 1, 0, 0, 0, 2, 4, 7>>}
+  """
+  @impl Serializable
+  def serialize(advertising_report) do
+    {:ok, bin} = Device.serialize(advertising_report.devices)
+    {:ok, <<@subevent_code, bin::binary>>}
   end
+
+  @doc """
+  Deserializes a LE Advertising Report Event into `Harald.HCI.Event.LEMeta.AdvertisingReport`
+  structs.
+
+      iex> AdvertisingReport.deserialize(
+      ...>   <<2, 2, 0, 1, 1, 2, 2, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 7, 6, 32, 1, 0, 0, 0, 2, 4,
+      ...>     7>>
+      ...> )
+      {:ok, %AdvertisingReport{
+          devices: [
+            %AdvertisingReport.Device{
+              event_type: 0,
+              address_type: 1,
+              address: 2,
+              data: [],
+              rss: 4
+            },
+            %AdvertisingReport.Device{
+              event_type: 1,
+              address_type: 2,
+              address: 5,
+              data: [{"Service Data - 32-bit UUID", %{uuid: 1, data: <<2>>}}],
+              rss: 7
+            }
+          ]
+        }
+      }
+  """
+  @impl Serializable
+  def deserialize(<<@subevent_code, arrayed_bin::binary>> = bin) do
+    case Device.deserialize(arrayed_bin) do
+      {:ok, devices} -> {:ok, %__MODULE__{devices: devices}}
+      {:error, _} -> {:error, bin}
+    end
+  end
+
+  def deserialize(bin), do: {:error, bin}
 end

--- a/lib/harald/hci/event/le_meta/advertising_report/device.ex
+++ b/lib/harald/hci/event/le_meta/advertising_report/device.ex
@@ -1,0 +1,365 @@
+defmodule Harald.HCI.Event.LEMeta.AdvertisingReport.Device do
+  @moduledoc """
+  A struct representing a single device within a LE Advertising Report.
+
+  > The LE Advertising Report event indicates that one or more Bluetooth devices have responded to
+  > an active scan or have broadcast advertisements that were received during a passive scan. The
+  > Controller may queue these advertising reports and send information from multiple devices in
+  > one LE Advertising Report event.
+  >
+  > This event shall only be generated if scanning was enabled using the LE Set Scan Enable
+  > command. It only reports advertising events that used legacy advertising PDUs.
+
+  Reference: Version 5.0, Vol 2, Part E, 7.7.65.2
+
+  The `:data` field of an `Harald.HCI.Event.LEMeta.AdvertisingReport.Device` struct represents AD
+  Structures.
+
+  > The significant part contains a sequence of AD structures. Each AD structure shall have a
+  > Length field of one octet, which contains the Length value, and a Data field of Length octets.
+
+  Reference: Version 5.0, Vol 3, Part C, 11
+  """
+
+  alias Harald.HCI.{ArrayedData, Event.LEMeta.AdvertisingReport.Device}
+  alias Harald.{ManufacturerData, Serializable, Transport.UART.Framing}
+  require Harald.AssignedNumbers.GenericAccessProfile, as: GenericAccessProfile
+
+  @enforce_keys [:event_type, :address_type, :address, :data, :rss]
+
+  defstruct @enforce_keys
+
+  @arrayed_data_schema [
+    event_type: 8,
+    address_type: 8,
+    address: 48,
+    length_data: {:variable, :data, 8},
+    data: :length_data,
+    rss: 8
+  ]
+
+  @type t :: %__MODULE__{}
+
+  @behaviour Serializable
+
+  @subevent_code 0x02
+
+  @doc """
+  See: `t:Harald.HCI.Event.LEMeta.subevent_code/0`.
+  """
+  def subevent_code, do: @subevent_code
+
+  @doc """
+  Serializes a list of `Harald.HCI.Event.LEMeta.AdvertisingReport` structs into a LE Advertising
+  Report Event.
+
+      iex> AdvertisingReport.serialize([
+      ...>   %AdvertisingReport{
+      ...>     event_type: 0,
+      ...>     address_type: 1,
+      ...>     address: 2,
+      ...>     data: [],
+      ...>     rss: 4
+      ...>   },
+      ...>   %AdvertisingReport{
+      ...>     event_type: 1,
+      ...>     address_type: 2,
+      ...>     address: 5,
+      ...>     data: [{"Service Data - 32-bit UUID", %{uuid: 1, data: <<2>>}}],
+      ...>     rss: 7
+      ...>   }
+      ...> ])
+      {:ok,
+       <<2, 2, 0, 1, 1, 2, 2, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 7, 6, 32, 1, 0, 0, 0, 2, 4, 7>>}
+  """
+  @impl Serializable
+  def serialize(devices) when is_list(devices) do
+    devices = for device <- devices, do: serialize_device_data(device)
+    ArrayedData.serialize(@arrayed_data_schema, devices)
+  end
+
+  @doc """
+  Given a list of `Harald.HCI.Event.LEMeta.AdvertisingReport.Device` structs', serializes their
+  `:data` fields into AD Structures.
+
+      iex> serialize_device_data(
+      ...>   %AdvertisingReport.Device{
+      ...>     address: 1,
+      ...>     address_type: 2,
+      ...>     data: [
+      ...>       {"Manufacturer Specific Data",
+      ...>        {"Apple, Inc.",
+      ...>         {"iBeacon",
+      ...>          %{
+      ...>            major: 4,
+      ...>            minor: 5,
+      ...>            tx_power: 6,
+      ...>            uuid: 7
+      ...>          }}}},
+      ...>       {"Service Data - 32-bit UUID", %{uuid: 8, data: <<9>>}}
+      ...>     ],
+      ...>     event_type: 1,
+      ...>     rss: 2
+      ...>   }
+      ...> )
+      [
+        %Harald.HCI.Event.LEMeta.AdvertisingReport.Device{
+          address: 1,
+          address_type: 2,
+          data: <<25, 255, 76, 2, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 4, 0, 5,
+                  6, 6, 32, 8, 0, 0, 0, 9>>,
+          event_type: 1,
+          rss: 2
+        }
+      ]
+  """
+  def serialize_device_data(device) do
+    Map.update!(device, :data, fn data ->
+      data
+      |> serialize_advertising_data()
+      |> case do
+        {:ok, bin} -> bin
+        {:error, _} = error -> error
+      end
+    end)
+  end
+
+  @doc """
+  Serializes a `Harald.HCI.Event.LEMeta.AdvertisingReport` struct's `:data` field into AD
+  Structures.
+
+      iex> serialize_advertising_data([
+      ...>   {"Manufacturer Specific Data",
+      ...>     {"Apple, Inc.",
+      ...>       {"iBeacon",
+      ...>         %{
+      ...>           major: 1,
+      ...>           minor: 2,
+      ...>           tx_power: 3,
+      ...>           uuid: 1
+      ...>         }}}},
+      ...>   {"Service Data - 32-bit UUID", %{uuid: 1, data: <<2>>}}
+      ...> ])
+      {:ok,
+       <<25, 255, 76, 2, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 2, 3, 6, 32,
+         1, 0, 0, 0, 2>>}
+  """
+  def serialize_advertising_data(ads, bin \\ <<>>)
+
+  def serialize_advertising_data([], bin) do
+    {:ok, bin}
+  end
+
+  def serialize_advertising_data([{:error, {:bad_length, length, data}} | ads], bin) do
+    serialize_advertising_data(ads, <<bin::bits, length, data::bits>>)
+  end
+
+  def serialize_advertising_data([{:error, {:unknown_type, {ad_type, ad_data}}} | ads], bin) do
+    data = <<ad_type, ad_data::bits>>
+    length = byte_size(data)
+    serialize_advertising_data(ads, <<bin::bits, length, data::bits>>)
+  end
+
+  def serialize_advertising_data([{:early_termination, 0} | ads], bin) do
+    serialize_advertising_data(ads, <<bin::bits, 0>>)
+  end
+
+  def serialize_advertising_data([{"Manufacturer Specific Data", data} | ads], bin) do
+    data
+    |> ManufacturerData.serialize()
+    |> case do
+      {:ok, company_bin} ->
+        manufacturer_data_bin = <<
+          GenericAccessProfile.id("Manufacturer Specific Data"),
+          company_bin::binary
+        >>
+
+        length = byte_size(manufacturer_data_bin)
+        serialize_advertising_data(ads, <<bin::bits, length, manufacturer_data_bin::binary>>)
+
+      {:error, {company_bin, data}} ->
+        manufacturer_data_bin = <<
+          GenericAccessProfile.id("Manufacturer Specific Data"),
+          company_bin::binary
+        >>
+
+        length = byte_size(manufacturer_data_bin)
+        {:error, {<<bin::bits, length, manufacturer_data_bin::binary>>, data, ads}}
+    end
+  end
+
+  def serialize_advertising_data(
+        [{"Service Data - 32-bit UUID", %{data: data, uuid: uuid}} | ads],
+        bin
+      ) do
+    service_data_32 = <<
+      GenericAccessProfile.id("Service Data - 32-bit UUID"),
+      uuid::little-size(32),
+      data::binary
+    >>
+
+    length = byte_size(service_data_32)
+    serialize_advertising_data(ads, <<bin::bits, length, service_data_32::binary>>)
+  end
+
+  def serialize_advertising_data([{ad_type, ad_data} | ads], bin) do
+    data = <<ad_type, ad_data::bits>>
+    length = byte_size(data)
+    serialize_advertising_data(ads, <<bin::bits, length, data::bits>>)
+  end
+
+  @doc """
+  Deserializes a LE Advertising Report Event into `Harald.HCI.Event.LEMeta.AdvertisingReport`
+  structs.
+
+      iex> AdvertisingReport.deserialize(
+      ...>   <<2, 2, 0, 1, 1, 2, 2, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 7, 6, 32, 1, 0, 0, 0, 2, 4,
+      ...>     7>>
+      ...> )
+      {:ok, [
+        %AdvertisingReport{
+          event_type: 0,
+          address_type: 1,
+          address: 2,
+          data: [],
+          rss: 4
+        },
+        %AdvertisingReport{
+          event_type: 1,
+          address_type: 2,
+          address: 5,
+          data: [{"Service Data - 32-bit UUID", %{uuid: 1, data: <<2>>}}],
+          rss: 7
+        }
+      ]}
+  """
+  @impl Serializable
+  def deserialize(<<num_reports, arrayed_parameters::binary>> = bin) do
+    @arrayed_data_schema
+    |> ArrayedData.deserialize(num_reports, Device, arrayed_parameters)
+    |> case do
+      {:ok, devices} -> deserialize_advertising_datas(devices)
+      {:error, _} -> {:error, bin}
+    end
+  end
+
+  def deserialize(bin), do: {:error, bin}
+
+  @doc """
+      iex> deserialize_advertising_data(<<25, 255, 76, 2, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ...>   0, 0, 0, 1, 0, 1, 0, 2, 3, 6, 32, 1, 0, 0, 0, 2>>)
+      {:ok, [
+        {"Manufacturer Specific Data", {"Apple, Inc.", {"iBeacon", %{
+          major: 1,
+          minor: 2,
+          tx_power: 3,
+          uuid: 1
+        }}}},
+        {"Service Data - 32-bit UUID", %{uuid: 1, data: <<2>>}}]
+      }
+  """
+  def deserialize_advertising_data(data, acc \\ {:ok, []})
+
+  def deserialize_advertising_data(<<>>, {status, ads}), do: {status, Enum.reverse(ads)}
+
+  # > If the Length field is set to zero, then the Data field has zero octets. This shall only
+  # > occur to allow an early termination of the Advertising or Scan Response data.
+  # Reference Version 5.0, Vol 3, Part C, 11
+  def deserialize_advertising_data(<<0, data::binary>>, {status, ads}) do
+    deserialize_advertising_data(data, {status, [{:early_termination, 0} | ads]})
+  end
+
+  def deserialize_advertising_data(<<length>>, {_, ads}) do
+    # AD Structure with a non-zero length and no data
+    deserialize_advertising_data(<<>>, {:error, [{:error, {:bad_length, length, <<>>}} | ads]})
+  end
+
+  def deserialize_advertising_data(<<length>> <> data, {status, ads}) do
+    data_length = byte_size(data)
+
+    case length > data_length do
+      true ->
+        # AD Structure with a non-zero length and not enough data
+        deserialize_advertising_data(
+          <<>>,
+          {:error, [{:error, {:bad_length, length, data}} | ads]}
+        )
+
+      false ->
+        {0, ad_structure, rest} = Framing.binary_split(data, length)
+
+        case deserialize_ads(ad_structure) do
+          {:ok, ad} ->
+            deserialize_advertising_data(rest, {status, [ad | ads]})
+
+          {:error, _} = error ->
+            deserialize_advertising_data(rest, {:error, [error | ads]})
+        end
+    end
+  end
+
+  @doc """
+  Deserializes AD Structures.
+
+      iex> deserialize_ads(<<0xFF, 76, 2, 0x15, 1::size(168)>>)
+      {:ok,
+       {"Manufacturer Specific Data",
+        {"Apple, Inc.", {"iBeacon", %{major: 0, minor: 0, tx_power: 1, uuid: 0}}}}}
+
+      iex> deserialize_ads(<<0x20, 1::size(40)>>)
+      {:ok, {"Service Data - 32-bit UUID", %{uuid: 0, data: <<1>>}}}
+
+      iex> deserialize_ads(<<0xFF>>)
+      {:error, {"Manufacturer Specific Data", {:error, {:unhandled_company_id, <<>>}}}}
+
+      iex> deserialize_ads(<<0x44, 1, 2, 3>>)
+      {:error, {:unknown_type, {0x44, <<1, 2, 3>>}}}
+  """
+  def deserialize_ads(<<GenericAccessProfile.id("Manufacturer Specific Data"), bin::binary>>) do
+    bin
+    |> ManufacturerData.deserialize()
+    |> case do
+      {:ok, data} -> {:ok, {"Manufacturer Specific Data", data}}
+      {:error, _} = error -> {:error, {"Manufacturer Specific Data", error}}
+    end
+  end
+
+  def deserialize_ads(<<GenericAccessProfile.id("Service Data - 32-bit UUID"), bin::binary>>) do
+    <<
+      uuid::little-size(32),
+      data::binary
+    >> = bin
+
+    service_data_32 = %{
+      uuid: uuid,
+      data: data
+    }
+
+    {:ok, {"Service Data - 32-bit UUID", service_data_32}}
+  end
+
+  def deserialize_ads(<<type, bin::bits>>) when type in GenericAccessProfile.ids() do
+    {:ok, {type, bin}}
+  end
+
+  def deserialize_ads(<<type, bin::bits>>), do: {:error, {:unknown_type, {type, bin}}}
+
+  defp deserialize_advertising_datas(devices) do
+    {status, devices} =
+      Enum.reduce(devices, {:ok, []}, fn device, {status, devices} ->
+        {status, device} = update_device(device, status)
+        {status, [device | devices]}
+      end)
+
+    {status, Enum.reverse(devices)}
+  end
+
+  defp update_device(device, status) do
+    Map.get_and_update(device, :data, fn data ->
+      case deserialize_advertising_data(data) do
+        {:ok, data} -> {status, data}
+        {:error, data} -> {:error, data}
+      end
+    end)
+  end
+end

--- a/lib/harald/hci/packet.ex
+++ b/lib/harald/hci/packet.ex
@@ -1,0 +1,20 @@
+defmodule Harald.HCI.Packet do
+  @moduledoc """
+  Functions and definitions relevant to HCI packets.
+  """
+
+  @doc """
+  Returns a keyword list definition of HCI packet types.
+
+  > There are four kinds of HCI packets that can be sent via the UART Transport Layer; i.e. HCI Command Packet, HCI Event Packet, HCI ACL Data Packet and HCI Synchronous Data Packet
+  Reference: Version 5.0, Vol 4, Part A, 2
+  """
+  def types do
+    [
+      # command: 0x01,
+      # acl_data: 0x02,
+      # synchronous_data: 0x03,
+      event: 0x04
+    ]
+  end
+end

--- a/lib/harald/serializable.ex
+++ b/lib/harald/serializable.ex
@@ -1,0 +1,9 @@
+defmodule Harald.Serializable do
+  @moduledoc """
+  Serializable behaviour.
+  """
+
+  @callback serialize(term()) :: {:ok, binary()} | {:error, term()}
+
+  @callback deserialize(binary()) :: {:ok, term()} | {:error, term()}
+end

--- a/lib/harald/transport/uart.ex
+++ b/lib/harald/transport/uart.ex
@@ -32,11 +32,8 @@ defmodule Harald.Transport.UART do
   @impl GenServer
   def init(args) do
     {:ok, pid} = UART.start_link()
-
     uart_opts = Keyword.merge([active: true, framing: {Framing, []}], args[:uart_opts])
-
     :ok = UART.open(pid, args[:device], uart_opts)
-
     {:ok, %{uart_pid: pid, parent_pid: args[:parent_pid]}}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,16 +1,24 @@
 defmodule Harald.MixProject do
   use Mix.Project
 
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
   def project do
     [
       app: :harald,
       deps: deps(),
       description: description(),
       dialyzer: [
-        flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs, :overspecs]
+        flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs, :overspecs],
+        ignore_warnings: "dialyzer_ignore.exs"
       ],
       docs: docs(),
       elixir: "~> 1.7",
+      elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       preferred_cli_env: [
         coveralls: :test,
@@ -22,12 +30,6 @@ defmodule Harald.MixProject do
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       version: "0.1.0"
-    ]
-  end
-
-  def application do
-    [
-      extra_applications: [:logger]
     ]
   end
 
@@ -57,6 +59,10 @@ defmodule Harald.MixProject do
       ]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["test/support", "lib"]
+
+  defp elixirc_paths(_), do: ["lib"]
 
   defp package do
     [

--- a/test/harald/hci/event/le_meta_test.exs
+++ b/test/harald/hci/event/le_meta_test.exs
@@ -1,0 +1,17 @@
+defmodule Harald.HCI.Event.LEMetaTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+  alias Harald.Generators.HCI.Event.LEMeta, as: LEMetaGen
+  alias Harald.HCI.Event.LEMeta
+
+  doctest LEMeta, import: true
+
+  property "symmetric (de)serialization" do
+    check all parameters <- LEMetaGen.parameters() do
+      case LEMeta.deserialize(parameters) do
+        {:ok, data} -> assert {:ok, parameters} == LEMeta.serialize(data)
+        {:error, _} -> :ok
+      end
+    end
+  end
+end

--- a/test/harald/hci/event_test.exs
+++ b/test/harald/hci/event_test.exs
@@ -1,22 +1,24 @@
 defmodule Harald.HCI.EventTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
+  alias Harald.Generators.HCI.Event, as: EventGen
   alias Harald.HCI.Event
 
   doctest Event, import: true
 
-  describe "parse/1" do
-    test "Event.Unparsed" do
-      # -1 will never be a event code that will one day be parsable.
-      assert %Event.Unparsed{event_code: -1, event: <<0>>} == Event.parse({-1, <<0>>})
+  property "symmetric (de)serialization" do
+    check all parameters <- EventGen.binary() do
+      case Event.deserialize(parameters) do
+        {:ok, data} -> assert {:ok, parameters} == Event.serialize(data)
+        {:error, _} -> :ok
+      end
     end
 
-    test "Event.LEMeta" do
-      data =
-        {0x3E,
-         <<2, 1, 0, 1, 108, 8, 100, 238, 199, 229, 14, 2, 1, 6, 3, 2, 175, 254, 6, 9, 78, 48, 53,
-           65, 81, 197>>}
-
-      assert [%Event.LEMeta.AdvertisingReport{}] = Event.parse(data)
+    check all parameters <- StreamData.binary() do
+      case Event.deserialize(parameters) do
+        {:ok, data} -> assert {:ok, parameters} == Event.serialize(data)
+        {:error, _} -> :ok
+      end
     end
   end
 end

--- a/test/harald/manufacturer_data/apple_test.exs
+++ b/test/harald/manufacturer_data/apple_test.exs
@@ -1,0 +1,18 @@
+defmodule Harald.ManufacturerData.AppleTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+  alias Harald.Generators.ManufacturerData.Apple, as: AppleGen
+  alias Harald.ManufacturerData.Apple
+
+  doctest Apple, import: true
+
+  property "symmetric (de)serialization" do
+    check all binary <- AppleGen.binary() do
+      assert {:ok, binary} ==
+               binary
+               |> Apple.deserialize()
+               |> elem(1)
+               |> Apple.serialize()
+    end
+  end
+end

--- a/test/harald/manufacturer_data_test.exs
+++ b/test/harald/manufacturer_data_test.exs
@@ -1,0 +1,24 @@
+defmodule Harald.ManufacturerDataTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+  alias Harald.Generators.ManufacturerData, as: ManufacturerDataGen
+  alias Harald.ManufacturerData
+
+  doctest ManufacturerData, import: true
+
+  property "symmetric (de)serialization" do
+    check all bin <- ManufacturerDataGen.binary() do
+      case ManufacturerData.deserialize(bin) do
+        {:ok, data} -> assert {:ok, bin} == ManufacturerData.serialize(data)
+        {:error, _} -> :ok
+      end
+    end
+
+    check all bin <- StreamData.binary() do
+      case ManufacturerData.deserialize(bin) do
+        {:ok, data} -> assert {:ok, bin} == ManufacturerData.serialize(data)
+        {:error, _} -> :ok
+      end
+    end
+  end
+end

--- a/test/harald/transport/uart/framing_test.exs
+++ b/test/harald/transport/uart/framing_test.exs
@@ -1,550 +1,84 @@
 defmodule Harald.Transport.UART.FramingTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
+  alias Harald.Generators
   alias Harald.Transport.UART.Framing
   alias Harald.Transport.UART.Framing.State
 
   doctest Harald.Transport.UART.Framing, import: true
 
-  test "init/1" do
-    check all args <- StreamData.term() do
-      assert {:ok, %State{}} == Framing.init(args)
+  describe "init/1" do
+    property "returns a fresh state" do
+      check all args <- StreamData.term() do
+        assert {:ok, %State{}} == Framing.init(args)
+      end
     end
   end
 
-  test "add_framing/2" do
-    check all data <- StreamData.binary(),
-              state <- StreamData.term() do
-      assert {:ok, data, state} == Framing.add_framing(data, state)
+  describe "add_framing/2" do
+    property "returns data and state unchanged" do
+      check all data <- StreamData.binary(),
+                state <- StreamData.term() do
+        assert {:ok, data, state} == Framing.add_framing(data, state)
+      end
     end
   end
 
   describe "flush/2" do
-    test ":transmit" do
+    property ":transmit returns state unchanged" do
       check all state <- StreamData.term() do
         assert state == Framing.flush(:transmit, state)
       end
     end
 
-    test ":receive" do
+    property ":receive returns a fresh state" do
       check all state <- StreamData.term() do
         assert %State{} == Framing.flush(:receive, state)
       end
     end
 
-    test ":both" do
+    property ":both returns a fresh state" do
       check all state <- StreamData.term() do
         assert %State{} == Framing.flush(:both, state)
       end
     end
   end
 
-  test "frame_timeout/1" do
-    check all state <- StreamData.term() do
-      assert {:ok, [state], <<>>} == Framing.frame_timeout(state)
-    end
-  end
-
-  describe "remove_framing/2 - general" do
-    test "empty data and empty state" do
-      assert {:ok, [], %State{}} == Framing.remove_framing(<<>>, %State{})
-    end
-  end
-
-  describe "remove_framing/2 - hci_packet_type 2" do
-    test "partial data and empty state" do
-      check all partial_data <- StreamData.binary(min_length: 1),
-                handle <- StreamData.integer(0..0x0EFF),
-                pb_flag <- StreamData.integer(0..3),
-                bc_flag <- StreamData.integer(0..3) do
-        remaining_bytes = 2
-        ev_length = byte_size(partial_data) + remaining_bytes
-
-        data =
-          <<
-            2,
-            handle::size(12),
-            pb_flag::size(2),
-            bc_flag::size(2),
-            ev_length::size(16)
-          >> <> partial_data
-
-        assert {:in_frame, [],
-                %State{
-                  event_type: 0,
-                  hci_packet_type: 2,
-                  in_process: partial_data,
-                  remaining_bytes: remaining_bytes
-                }} == Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "partial data and partial state" do
-      check all partial_a <- StreamData.binary(min_length: 1) do
-        state = %State{
-          event_type: 0,
-          hci_packet_type: 2,
-          in_process: "",
-          remaining_bytes: byte_size(partial_a) + 2
-        }
-
-        assert {:in_frame, [],
-                %State{
-                  event_type: 0,
-                  hci_packet_type: 2,
-                  in_process: partial_a,
-                  remaining_bytes: 2
-                }} == Framing.remove_framing(partial_a, state)
-      end
-    end
-
-    test "remaining data and partial state" do
-      check all partial <- StreamData.binary(min_length: 1),
-                remaining <- StreamData.binary(min_length: 1) do
-        state = %State{
-          event_type: 0,
-          hci_packet_type: 2,
-          in_process: partial,
-          remaining_bytes: byte_size(remaining)
-        }
-
-        assert {:ok, [], %State{}} = Framing.remove_framing(remaining, state)
-      end
-    end
-
-    test "full data and empty state" do
-      check all payload <- StreamData.binary(min_length: 1),
-                handle <- StreamData.integer(0..0x0EFF),
-                pb_flag <- StreamData.integer(0..3),
-                bc_flag <- StreamData.integer(0..3) do
-        payload_length = byte_size(payload)
-
-        data = <<
-          2,
-          handle::size(12),
-          pb_flag::size(2),
-          bc_flag::size(2),
-          payload_length::size(16),
-          payload::binary
-        >>
-
-        assert {:ok, [], %State{}} = Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "data continuation that starts with a 2" do
-      assert {:ok, [], %State{}} =
-               Framing.remove_framing(<<2, 5>>, %State{
-                 event_type: 0,
-                 hci_packet_type: 2,
-                 in_process: "",
-                 remaining_bytes: 2
-               })
-    end
-
-    test "multiple full frames ending with a partial frame" do
-      check all payloads <- StreamData.list_of(StreamData.binary(min_length: 1), min_length: 1),
-                partial <- StreamData.binary(min_length: 1),
-                handle <- StreamData.integer(0..0x0EFF),
-                pb_flag <- StreamData.integer(0..3),
-                bc_flag <- StreamData.integer(0..3) do
-        full_frames =
-          for p <- payloads, into: "" do
-            p_length = byte_size(p)
-
-            <<
-              2,
-              handle::size(12),
-              pb_flag::size(2),
-              bc_flag::size(2),
-              p_length::size(16),
-              p::binary
-            >>
-          end
-
-        partial_length = byte_size(partial) + 2
-
-        data =
-          full_frames <>
-            <<
-              2,
-              handle::size(12),
-              pb_flag::size(2),
-              bc_flag::size(2),
-              partial_length::size(16),
-              partial::binary
-            >>
-
-        expected_state = %State{
-          event_type: 0,
-          hci_packet_type: 2,
-          in_process: partial,
-          remaining_bytes: 2
-        }
-
-        assert {:in_frame, [], expected_state} == Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "partial that does not include length initially" do
-      check all messages <- StreamData.list_of(StreamData.binary(min_length: 1), min_length: 1) do
-        messages_data =
-          for m <- messages, into: "" do
-            m_length = byte_size(m)
-            <<2, 0::size(16), m_length::size(16)>> <> m
-          end
-
-        data0 = messages_data <> <<2>>
-
-        state0 = %State{
-          event_type: 0,
-          hci_packet_type: nil,
-          in_process: <<2>>,
-          remaining_bytes: nil
-        }
-
-        assert {:in_frame, [], state0} == Framing.remove_framing(data0, %State{})
-
-        data1 = <<0::size(16)>>
-        state1 = %{state0 | in_process: state0.in_process <> data1}
-
-        assert {:in_frame, [], state1} == Framing.remove_framing(data1, state0)
-
-        ev_length = 10
-        data2 = <<ev_length::size(16)>>
-
-        state2 = %{
-          state1
-          | event_type: 0,
-            hci_packet_type: 2,
-            in_process: <<>>,
-            remaining_bytes: ev_length
-        }
-
-        assert {:in_frame, [], state2} == Framing.remove_framing(data2, state1)
+  describe "frame_timeout/1" do
+    property "returns the state and an empty binary" do
+      check all state <- StreamData.term() do
+        assert {:ok, [state], <<>>} == Framing.frame_timeout(state)
       end
     end
   end
 
-  describe "remove_framing/2 - hci_packet_type 3" do
-    test "partial data and empty state" do
-      check all partial_data <- StreamData.binary(min_length: 1),
-                connection_handle <- StreamData.integer(0..0x0EFF),
-                packet_status_flag <- StreamData.integer(0..3),
-                rfu <- StreamData.integer(0..3) do
-        remaining_bytes = 2
-        ev_length = byte_size(partial_data)
-
-        data =
-          <<
-            3,
-            connection_handle::size(12),
-            packet_status_flag::size(2),
-            rfu::size(2),
-            ev_length + remaining_bytes
-          >> <> partial_data
-
-        assert {:in_frame, [],
-                %State{
-                  event_type: 0,
-                  hci_packet_type: 3,
-                  in_process: partial_data,
-                  remaining_bytes: remaining_bytes
-                }} == Framing.remove_framing(data, %State{})
+  describe "remove_framing/2" do
+    property "bad packet types return the remaining data in error" do
+      check all packet_type <- StreamData.integer(),
+                packet_type not in 2..4,
+                rest <- StreamData.bitstring(),
+                binary = <<packet_type, rest::bits>> do
+        assert {:ok, [{:error, {:bad_packet_type, binary}}], %State{}} ==
+                 Framing.remove_framing(binary, %State{})
       end
     end
 
-    test "partial data and partial state" do
-      check all partial_a <- StreamData.binary(min_length: 1) do
-        state = %State{
-          event_type: 0,
-          hci_packet_type: 3,
-          in_process: "",
-          remaining_bytes: byte_size(partial_a) + 2
-        }
-
-        assert {:in_frame, [],
-                %State{
-                  event_type: 0,
-                  hci_packet_type: 3,
-                  in_process: partial_a,
-                  remaining_bytes: 2
-                }} == Framing.remove_framing(partial_a, state)
+    property "returns when receiving a complete binary of packets" do
+      check all packets <- StreamData.list_of(Generators.HCI.packet()),
+                binary = Enum.join(packets) do
+        assert {:ok, ^packets, %{frame: "", remaining_bytes: nil}} =
+                 Framing.remove_framing(binary, %State{})
       end
     end
 
-    test "remaining data and partial state" do
-      check all partial <- StreamData.binary(min_length: 1),
-                remaining <- StreamData.binary(min_length: 1) do
-        state = %State{
-          event_type: 0,
-          hci_packet_type: 3,
-          in_process: partial,
-          remaining_bytes: byte_size(remaining)
-        }
-
-        assert {:ok, [], %State{}} = Framing.remove_framing(remaining, state)
-      end
-    end
-
-    test "full data and empty state" do
-      check all payload <- StreamData.binary(min_length: 1),
-                connection_handle <- StreamData.integer(0..0x0EFF),
-                packet_status_flag <- StreamData.integer(0..3),
-                rfu <- StreamData.integer(0..3) do
-        payload_length = byte_size(payload)
-
-        data = <<
-          3,
-          connection_handle::size(12),
-          packet_status_flag::size(2),
-          rfu::size(2),
-          payload_length::size(8),
-          payload::binary
-        >>
-
-        assert {:ok, [], %State{}} = Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "data continuation that starts with a 3" do
-      assert {:ok, [], %State{}} =
-               Framing.remove_framing(<<3, 5>>, %State{
-                 event_type: 0,
-                 hci_packet_type: 3,
-                 in_process: "",
-                 remaining_bytes: 2
-               })
-    end
-
-    test "multiple full frames ending with a partial frame" do
-      check all payloads <- StreamData.list_of(StreamData.binary(min_length: 1), min_length: 1),
-                partial <- StreamData.binary(min_length: 1),
-                connection_handle <- StreamData.integer(0..0x0EFF),
-                packet_status_flag <- StreamData.integer(0..3),
-                rfu <- StreamData.integer(0..3) do
-        full_frames =
-          for p <- payloads, into: "" do
-            p_length = byte_size(p)
-
-            <<
-              3,
-              connection_handle::size(12),
-              packet_status_flag::size(2),
-              rfu::size(2),
-              p_length::size(8),
-              p::binary
-            >>
-          end
-
-        partial_length = byte_size(partial) + 2
-
-        data =
-          full_frames <>
-            <<
-              3,
-              connection_handle::size(12),
-              packet_status_flag::size(2),
-              rfu::size(2),
-              partial_length::size(8),
-              partial::binary
-            >>
-
-        expected_state = %State{
-          event_type: 0,
-          hci_packet_type: 3,
-          in_process: partial,
-          remaining_bytes: 2
-        }
-
-        assert {:in_frame, [], expected_state} == Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "partial that does not include length initially" do
-      check all messages <- StreamData.list_of(StreamData.binary(min_length: 1), min_length: 1) do
-        messages_data =
-          for m <- messages, into: "" do
-            m_length = byte_size(m)
-            <<3, 0::size(16), m_length>> <> m
-          end
-
-        data0 = messages_data <> <<3>>
-
-        state0 = %State{
-          event_type: 0,
-          hci_packet_type: nil,
-          in_process: <<3>>,
-          remaining_bytes: nil
-        }
-
-        ret = Framing.remove_framing(data0, %State{})
-        assert {:in_frame, [], state0} == ret
-
-        data1 = <<0::size(16)>>
-        state1 = %{state0 | in_process: state0.in_process <> data1}
-
-        assert {:in_frame, [], state1} == Framing.remove_framing(data1, state0)
-
-        ev_length = 10
-        data2 = <<ev_length>>
-
-        state2 = %{
-          state1
-          | event_type: 0,
-            hci_packet_type: 3,
-            in_process: <<>>,
-            remaining_bytes: ev_length
-        }
-
-        assert {:in_frame, [], state2} == Framing.remove_framing(data2, state1)
-      end
-    end
-  end
-
-  describe "remove_framing/2 - hci_packet_type 4" do
-    test "partial data and empty state" do
-      check all partial_event <- StreamData.binary(min_length: 1),
-                event_type <- StreamData.integer(0..255) do
-        remaining_bytes = 2
-        ev_length = byte_size(partial_event)
-        data = <<4, event_type, ev_length + remaining_bytes>> <> partial_event
-
-        assert {:in_frame, [],
-                %State{
-                  event_type: event_type,
-                  hci_packet_type: 4,
-                  in_process: partial_event,
-                  remaining_bytes: remaining_bytes
-                }} == Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "partial data and partial state" do
-      check all partial_a <- StreamData.binary(min_length: 1),
-                partial_b <- StreamData.binary(min_length: 1),
-                event_type <- StreamData.integer(0..255) do
-        state = %State{
-          event_type: event_type,
-          hci_packet_type: 4,
-          in_process: partial_a,
-          remaining_bytes: byte_size(partial_b) + 2
-        }
-
-        assert {:in_frame, [],
-                %State{
-                  event_type: event_type,
-                  hci_packet_type: 4,
-                  in_process: partial_a <> partial_b,
-                  remaining_bytes: 2
-                }} == Framing.remove_framing(partial_b, state)
-      end
-    end
-
-    test "remaining data and partial state" do
-      check all partial <- StreamData.binary(min_length: 1),
-                remaining <- StreamData.binary(min_length: 1),
-                event_type <- StreamData.integer(0..255) do
-        state = %State{
-          event_type: event_type,
-          hci_packet_type: 4,
-          in_process: partial,
-          remaining_bytes: byte_size(remaining)
-        }
-
-        message = partial <> remaining
-
-        assert {:ok, [{event_type, ^message}], %State{}} =
-                 Framing.remove_framing(remaining, state)
-      end
-    end
-
-    test "full data and empty state" do
-      check all message <- StreamData.binary(min_length: 1),
-                event_type <- StreamData.integer(0..255) do
-        message_length = byte_size(message)
-        data = <<4, event_type, message_length>> <> message
-
-        assert {:ok, [{^event_type, ^message}], %State{}} = Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "data continuation that starts with a 4" do
-      assert {:ok, [{0, <<1, 2, 3, 4, 5>>}], %State{}} =
-               Framing.remove_framing(<<4, 5>>, %State{
-                 event_type: 0,
-                 hci_packet_type: 4,
-                 in_process: <<1, 2, 3>>,
-                 remaining_bytes: 2
-               })
-    end
-
-    test "multiple full frames ending with a partial frame" do
-      check all messages <- StreamData.list_of(StreamData.binary(min_length: 1), min_length: 1),
-                partial <- StreamData.binary(min_length: 1),
-                event_type <- StreamData.integer(0..255) do
-        messages_data =
-          for m <- messages, into: "" do
-            m_length = byte_size(m)
-            <<4, event_type, m_length>> <> m
-          end
-
-        expected_messages = for m <- messages, do: {event_type, m}
-
-        partial_length = byte_size(partial) + 2
-        data = messages_data <> <<4, event_type, partial_length>> <> partial
-
-        expected_state = %State{
-          event_type: event_type,
-          hci_packet_type: 4,
-          in_process: partial,
-          remaining_bytes: 2
-        }
-
-        assert {:in_frame, expected_messages, expected_state} ==
-                 Framing.remove_framing(data, %State{})
-      end
-    end
-
-    test "partial that does not include length initially" do
-      check all messages <- StreamData.list_of(StreamData.binary(min_length: 1), min_length: 1),
-                event_type <- StreamData.integer(0..255) do
-        messages_data =
-          for m <- messages, into: "" do
-            m_length = byte_size(m)
-            <<4, event_type, m_length>> <> m
-          end
-
-        expected_messages = for m <- messages, do: {event_type, m}
-
-        data0 = messages_data <> <<4>>
-
-        state0 = %State{
-          event_type: 0,
-          hci_packet_type: nil,
-          in_process: <<4>>,
-          remaining_bytes: nil
-        }
-
-        assert {:in_frame, expected_messages, state0} == Framing.remove_framing(data0, %State{})
-
-        data1 = <<0x3E>>
-        state1 = %{state0 | in_process: state0.in_process <> data1}
-
-        assert {:in_frame, [], state1} == Framing.remove_framing(data1, state0)
-
-        ev_length = 10
-        data2 = <<ev_length>>
-
-        state2 = %{
-          state1
-          | event_type: 0x3E,
-            hci_packet_type: 4,
-            in_process: <<>>,
-            remaining_bytes: ev_length
-        }
-
-        assert {:in_frame, [], state2} == Framing.remove_framing(data2, state1)
+    property "returns when receiving a binary of packets that will end in_frame" do
+      check all [head | tail] <- StreamData.list_of(Generators.HCI.packet(), length: 1),
+                packets = Enum.join(tail),
+                head_length = byte_size(head),
+                partial_length <- StreamData.integer(1..(head_length - 1)),
+                {0, partial_packet, _} = Framing.binary_split(head, partial_length) do
+        assert {:in_frame, ^tail, %{frame: ^partial_packet}} =
+                 Framing.remove_framing(packets <> partial_packet, %State{})
       end
     end
   end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -1,0 +1,12 @@
+defmodule Harald.Generators do
+  @moduledoc """
+  StreamData generators.
+  """
+
+  use ExUnitProperties
+
+  def generator_for(module) do
+    [head | tail] = Module.split(module)
+    Module.concat([head, "Generators" | tail])
+  end
+end

--- a/test/support/generators/hci.ex
+++ b/test/support/generators/hci.ex
@@ -1,0 +1,20 @@
+defmodule Harald.Generators.HCI do
+  @moduledoc """
+  StreamData generators for HCI.
+  """
+
+  use ExUnitProperties
+  alias Harald.Generators.HCI.Event, as: EventGen
+  alias Harald.HCI.Packet
+
+  @spec packet :: no_return()
+  def packet do
+    gen all {type, indicator} <- StreamData.member_of(Packet.types()),
+            binary <- packet(type) do
+      <<indicator, binary::binary>>
+    end
+  end
+
+  @spec packet(:event) :: no_return()
+  def packet(:event), do: EventGen.binary()
+end

--- a/test/support/generators/hci/event.ex
+++ b/test/support/generators/hci/event.ex
@@ -1,0 +1,23 @@
+defmodule Harald.Generators.HCI.Event do
+  @moduledoc """
+  StreamData generators for HCI Event Packets.
+
+  Reference: Version 5.0, Vol 2, Part E, 5.4.4
+  """
+
+  use ExUnitProperties
+  alias Harald.Generators
+  alias Harald.HCI.{Event, Event.LEMeta}
+
+  @doc """
+  Returns a partial HCI Event packet binary for a random event, everything besides the HCI packet
+  indicator.
+  """
+  @spec binary :: no_return()
+  def binary do
+    gen all module <- StreamData.member_of(Event.event_modules()),
+            parameters <- Generators.generator_for(module).parameters() do
+      <<module.event_code(), byte_size(parameters), parameters::binary>>
+    end
+  end
+end

--- a/test/support/generators/hci/event/inquiry_complete.ex
+++ b/test/support/generators/hci/event/inquiry_complete.ex
@@ -1,0 +1,17 @@
+defmodule Harald.Generators.HCI.Event.InquiryComplete do
+  @moduledoc """
+  StreamData generators for Inquiry Complete event.
+
+  Reference: Version 5.0, Vol 2, Part E, 7.7.1
+  """
+
+  use ExUnitProperties
+  alias Harald.ErrorCode
+
+  @spec parameters :: no_return()
+  def parameters do
+    gen all {status, _} <- StreamData.member_of(ErrorCode.all()) do
+      <<status>>
+    end
+  end
+end

--- a/test/support/generators/hci/event/le_meta.ex
+++ b/test/support/generators/hci/event/le_meta.ex
@@ -1,0 +1,18 @@
+defmodule Harald.Generators.HCI.Event.LEMeta do
+  @moduledoc """
+  StreamData generators for the LEMeta event.
+
+  Reference: Version 5.0, Vol 2, Part E, 7.7.65
+  """
+
+  use ExUnitProperties
+  alias Harald.{Generators, HCI.Event.LEMeta}
+
+  @spec parameters :: no_return()
+  def parameters do
+    gen all subevent_module <- StreamData.member_of(LEMeta.subevent_modules()),
+            parameters <- Generators.generator_for(subevent_module).parameters() do
+      parameters
+    end
+  end
+end

--- a/test/support/generators/hci/event/le_meta/advertising_report.ex
+++ b/test/support/generators/hci/event/le_meta/advertising_report.ex
@@ -1,0 +1,68 @@
+defmodule Harald.Generators.HCI.Event.LEMeta.AdvertisingReport do
+  @moduledoc """
+  StreamData generators for LE Advertising Report event.
+
+  Reference: Version 5.0, Vol 2, Part E, 7.7.65.2
+  """
+
+  use ExUnitProperties
+  alias Harald.HCI.Event.LEMeta.AdvertisingReport
+
+  defp calc_max_data_size(num_reports), do: 253 - 10 * num_reports
+
+  @spec parameters :: no_return()
+  def parameters do
+    array_range = fn range, num_reports ->
+      bind(
+        list_of(map(integer(range), &<<&1>>), length: num_reports),
+        fn list -> constant(Enum.join(list)) end
+      )
+    end
+
+    gen_data = fn len, max ->
+      gen all raw_list <- list_of(integer(0x00..0x1F), length: len),
+              list = dampen_list(raw_list, max),
+              length_datas = Enum.into(list, <<>>, &<<&1>>),
+              datas = Enum.into(list, <<>>, &Enum.at(binary(length: &1), 0)) do
+        {length_datas, datas}
+      end
+    end
+
+    gen all num_reports <- integer(0x01..0x19),
+            max_data_size = calc_max_data_size(num_reports),
+            {length_datas, datas} <- gen_data.(num_reports, max_data_size),
+            event_types <- array_range.(0x00..0x04, num_reports),
+            address_types <- array_range.(0x00..0x03, num_reports),
+            address_list <- list_of(binary(length: 6), length: num_reports),
+            addresses = Enum.join(address_list),
+            rss <- array_range.(-127..126, num_reports) do
+      <<
+        AdvertisingReport.subevent_code(),
+        num_reports,
+        event_types::binary,
+        address_types::binary,
+        addresses::binary,
+        length_datas::binary,
+        datas::binary,
+        rss::binary
+      >>
+    end
+  end
+
+  defp dampen_list(list, max) do
+    if Enum.sum(list) <= max do
+      list
+    else
+      list
+      |> map_decrement()
+      |> dampen_list(max)
+    end
+  end
+
+  defp map_decrement(list) do
+    Enum.map(list, fn
+      0 -> 0
+      x -> x - 1
+    end)
+  end
+end

--- a/test/support/generators/manufacturer_data.ex
+++ b/test/support/generators/manufacturer_data.ex
@@ -1,0 +1,18 @@
+defmodule Harald.Generators.ManufacturerData do
+  @moduledoc """
+  StreamData generators for manufacturer data.
+  """
+
+  use ExUnitProperties
+  alias Harald.{Generators, ManufacturerData}
+  require Harald.AssignedNumbers.GenericAccessProfile, as: GenericAccessProfile
+
+  @spec binary :: no_return()
+  def binary do
+    gen all modules <- StreamData.constant(ManufacturerData.modules()),
+            module <- StreamData.one_of(modules),
+            bin <- Generators.generator_for(module).binary() do
+      <<GenericAccessProfile.id("Manufacturer Specific Data"), bin::binary>>
+    end
+  end
+end

--- a/test/support/generators/manufacturer_data/apple.ex
+++ b/test/support/generators/manufacturer_data/apple.ex
@@ -1,0 +1,23 @@
+defmodule Harald.Generators.ManufacturerData.Apple do
+  @moduledoc """
+  StreamData generators for Apple manufacturer data.
+
+  ## iBeacon
+
+  Reference: https://en.wikipedia.org/wiki/IBeacon#Packet_Structure_Byte_Map
+  """
+
+  use ExUnitProperties
+  alias Harald.ManufacturerData.Apple
+
+  @spec binary :: no_return()
+  def binary do
+    gen all bin <- StreamData.binary(length: 21) do
+      <<
+        Apple.ibeacon_identifier(),
+        Apple.ibeacon_length(),
+        bin::binary
+      >>
+    end
+  end
+end


### PR DESCRIPTION
Work towards consistent patterns of serializing BT data, leverage
property testing more, and DRY out code.

--

Monster PR here. Attempting to pull it apart was not productive. Test coverage
increases to 70%. We can handle multiple reports in an advertising report now (Resolves #13).
Dedicated modules for static data like Company Identifiers, Generic Access
Profile, and Error Codes. Added a ton of docs and links into the core spec.
Generic module for Arrayed Data that can be used going forward. Added an
implementation for the Inquiry Complete event to test non-LEMeta events as they
take a different code path. Make the `AdvertisingReport` struct hold 25 devices,
rather than having 25 advertising reports, consequently this introduces the
`AdvertisingData.Device` struct. This is more in line with how the spec
describes this event, and makes serialization code more straightforward.
Simplified framing a bit and added comments. Added a ton of tests, leveraging
symmetric serialization as a property where possible. Pattern started for
defining module to handle manufacturing data, Apple being the first one.

Tested on rpi3 that scanning still works.

Happy to discuss anything.